### PR TITLE
当用户在pom.xml中配置了<directory>, testable-agent.log将不会生成

### DIFF
--- a/testable-agent/src/main/java/com/alibaba/testable/agent/util/GlobalConfig.java
+++ b/testable-agent/src/main/java/com/alibaba/testable/agent/util/GlobalConfig.java
@@ -102,7 +102,9 @@ public class GlobalConfig {
         String contextFolder = System.getProperty(PROPERTY_USER_DIR);
         URL rootResourceFolder = Object.class.getResource(SLASH);
         if (rootResourceFolder != null) {
-            return PathUtil.getFirstLevelFolder(contextFolder, rootResourceFolder.getPath());
+            // if user pom.xml was set <directory>/other/path</directory>, then PathUtil.getFirstLevelFolder will return ""
+            String outputFolder = PathUtil.getFirstLevelFolder(contextFolder, rootResourceFolder.getPath());
+            return outputFolder.isEmpty() ? rootResourceFolder.getPath() + "../" : outputFolder;    
         } else if (PathUtil.folderExists(PathUtil.join(contextFolder, DEFAULT_MAVEN_OUTPUT_FOLDER))) {
             return PathUtil.join(contextFolder, DEFAULT_MAVEN_OUTPUT_FOLDER);
         } else if (PathUtil.folderExists(PathUtil.join(contextFolder, DEFAULT_GRADLE_OUTPUT_FOLDER))) {


### PR DESCRIPTION
当用户在pom.xml中指定了Build folder时，com.alibaba.testable.agent.util.GlobalConfig#getBuildOutputFolder 将不能正确的获取当前build目录