### PR TITLE
fixed static instance reference issue

### DIFF
--- a/demo/java-demo/src/main/java/com/alibaba/demo/lambda/StaticInstanceReference.java
+++ b/demo/java-demo/src/main/java/com/alibaba/demo/lambda/StaticInstanceReference.java
@@ -1,0 +1,79 @@
+package com.alibaba.demo.lambda;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * @author jim
+ */
+public class StaticInstanceReference {
+
+    private static A a = new A();
+
+    public void staticMethodReference() {
+        //consumesRun(() -> a.doIt());
+        //A b = new A();
+        //consumesRun(b::doIt);
+        consumesRun(a::doIt);
+        consumesFunction1(a::function1);
+        consumesFunction2(a::function2);
+        consumesFunction3(a::function3);
+    }
+
+    private void consumesRun(Runnable r) {
+        r.run();
+    }
+
+    private <T> void consumesFunction1(Consumer<T> r) {
+        r.accept(null);
+    }
+
+    private <T, R> void consumesFunction2(Function<T, R> r) {
+        r.apply(null);
+    }
+
+    private <T1, T2, R> void consumesFunction3(BiFunction<T1, T2, R> r) {
+        r.apply(null, null);
+    }
+
+   public static class A {
+        public void doIt() {
+
+        }
+
+        public void function1(String s) {
+
+        }
+
+       public Integer function2(String s) {
+            return 1;
+       }
+
+       public Integer function3(String s, Double d) {
+           return 1;
+       }
+   }
+
+   public static class XBean {
+        private Long id;
+
+       public Long getId() {
+           return id;
+       }
+
+       public void setId(Long id) {
+           this.id = id;
+       }
+   }
+
+    public void foo() {
+        List<XBean> testList = Collections.emptyList();
+        //noinspection RedundantOperationOnEmptyContainer
+        List<Long> response = testList.stream().map(XBean::getId).distinct().collect(Collectors.toList());
+    }
+
+}

--- a/demo/java-demo/src/test/java/com/alibaba/demo/lambda/StaticInstanceReferenceTest.java
+++ b/demo/java-demo/src/test/java/com/alibaba/demo/lambda/StaticInstanceReferenceTest.java
@@ -1,0 +1,30 @@
+package com.alibaba.demo.lambda;
+
+import com.alibaba.testable.core.annotation.MockDiagnose;
+import com.alibaba.testable.core.annotation.MockInvoke;
+import com.alibaba.testable.core.model.LogLevel;
+import org.junit.jupiter.api.Test;
+
+import static com.alibaba.testable.core.matcher.InvocationVerifier.verifyInvoked;
+
+
+/**
+ * @author jim
+ */
+public class StaticInstanceReferenceTest {
+
+    private StaticInstanceReference instance = new StaticInstanceReference();
+
+    //@MockDiagnose(LogLevel.VERBOSE)
+    public static class Mock {
+        @MockInvoke(targetClass = StaticInstanceReference.A.class, targetMethod = "doIt")
+        private void mockDoIt() {
+        }
+    }
+
+    @Test
+    public void shouldMockT1() {
+        instance.staticMethodReference();
+        verifyInvoked("mockDoIt").withTimes(1);
+    }
+}

--- a/testable-agent/src/main/java/com/alibaba/testable/agent/handler/SourceClassHandler.java
+++ b/testable-agent/src/main/java/com/alibaba/testable/agent/handler/SourceClassHandler.java
@@ -433,7 +433,8 @@ public class SourceClassHandler extends BaseClassHandler {
                 mv.visitVarInsn(getLoadType(arg), isStatic ? i : i + 1);
             }
 
-            mv.visitMethodInsn(isStatic ? INVOKESTATIC : INVOKEVIRTUAL, handle.getOwner(), handle.getName(), desc, false);
+            // the method call is static ?
+            mv.visitMethodInsn(Opcodes.H_INVOKESTATIC == tag ? INVOKESTATIC : INVOKEVIRTUAL, handle.getOwner(), handle.getName(), desc, false);
 
             mv.visitInsn(getReturnType(returnType));
 


### PR DESCRIPTION
```
public class StaticInstanceReference {

    private static A a = new A();


    public void staticMethodReference() {
        //consumesRun(() -> a.doIt());
        consumesRun(a::doIt);
        //A b = new A();
        //consumesRun(b::doIt);
    }

    private void consumesRun(Runnable r) {
        r.run();
    }

   public static class A {
        public void doIt() {

        }
   }
}
```
修复类似这种静态实例的方法引用
