### PR TITLE
Fixed interface default method

### DIFF
--- a/demo/java-demo/src/main/java/com/alibaba/demo/lambda/StaticInstanceReference.java
+++ b/demo/java-demo/src/main/java/com/alibaba/demo/lambda/StaticInstanceReference.java
@@ -1,10 +1,7 @@
 package com.alibaba.demo.lambda;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -18,19 +15,29 @@ public class StaticInstanceReference {
     private static final StaticClassA STATIC_CLASS_A = new StaticClassA();
 
     public void staticMethodReference() {
-        StaticClassA a = new StaticClassA();
-        consumesRun(a::doIt);
+        //StaticClassA a = new StaticClassA();
+        //consumesRun(a::doIt);
         consumesRun(STATIC_CLASS_A::doIt);
         consumesFunction1(STATIC_CLASS_A::function1);
         consumesFunction2(STATIC_CLASS_A::function2);
         consumesFunction3(STATIC_CLASS_A::function3);
+
+    }
+
+    public void collectionInterfaceDefaultOrStatic() {
         blackHole(invokeInterfaceTest());
+        blackHole(interfaceStaticMethodTest());
     }
 
     public void interfaceDefault() {
         ILambda l = new LambdaFoo();
         consumesRun(l::run);
         consumesFunction1(l::function1);
+    }
+
+    public void interfaceStatic() {
+        consumesRun(ILambda::staticRun);
+        consumesFunction1(ILambda::staticFunction1);
     }
 
     private void consumesRun(Runnable r) {
@@ -96,6 +103,16 @@ public class StaticInstanceReference {
                 .reduce(BigDecimal::add);
     }
 
+    public Object interfaceStaticMethodTest() {
+        List<String[]> zz = new ArrayList<>();
+        zz.add(new String[]{"1"});
+        return zz.stream()
+                .flatMap(Arrays::stream)
+                .map(Double::valueOf)
+                .map(BigDecimal::new)
+                .reduce(BigDecimal::add);
+    }
+
     private void blackHole(Object... ignore) {}
 
     public interface ILambda {
@@ -104,6 +121,14 @@ public class StaticInstanceReference {
         }
 
         default void function1(String s) {
+
+        }
+
+        static void staticRun() {
+
+        }
+
+        static void staticFunction1(String s) {
 
         }
     }

--- a/demo/java-demo/src/main/java/com/alibaba/demo/lambda/StaticInstanceReference.java
+++ b/demo/java-demo/src/main/java/com/alibaba/demo/lambda/StaticInstanceReference.java
@@ -1,5 +1,8 @@
 package com.alibaba.demo.lambda;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -12,16 +15,22 @@ import java.util.stream.Collectors;
  */
 public class StaticInstanceReference {
 
-    private static A a = new A();
+    private static final StaticClassA STATIC_CLASS_A = new StaticClassA();
 
     public void staticMethodReference() {
-        //consumesRun(() -> a.doIt());
-        //A b = new A();
-        //consumesRun(b::doIt);
+        StaticClassA a = new StaticClassA();
         consumesRun(a::doIt);
-        consumesFunction1(a::function1);
-        consumesFunction2(a::function2);
-        consumesFunction3(a::function3);
+        consumesRun(STATIC_CLASS_A::doIt);
+        consumesFunction1(STATIC_CLASS_A::function1);
+        consumesFunction2(STATIC_CLASS_A::function2);
+        consumesFunction3(STATIC_CLASS_A::function3);
+        blackHole(invokeInterfaceTest());
+    }
+
+    public void interfaceDefault() {
+        ILambda l = new LambdaFoo();
+        consumesRun(l::run);
+        consumesFunction1(l::function1);
     }
 
     private void consumesRun(Runnable r) {
@@ -40,35 +49,34 @@ public class StaticInstanceReference {
         r.apply(null, null);
     }
 
-   public static class A {
+    public static class StaticClassA {
         public void doIt() {
-
         }
 
         public void function1(String s) {
 
         }
 
-       public Integer function2(String s) {
+        public Integer function2(String s) {
             return 1;
-       }
+        }
 
-       public Integer function3(String s, Double d) {
-           return 1;
-       }
-   }
+        public Integer function3(String s, Double d) {
+            return 1;
+        }
+    }
 
-   public static class XBean {
+    public static class XBean {
         private Long id;
 
-       public Long getId() {
-           return id;
-       }
+        public Long getId() {
+            return id;
+        }
 
-       public void setId(Long id) {
-           this.id = id;
-       }
-   }
+        public void setId(Long id) {
+            this.id = id;
+        }
+    }
 
     public void foo() {
         List<XBean> testList = Collections.emptyList();
@@ -76,4 +84,31 @@ public class StaticInstanceReference {
         List<Long> response = testList.stream().map(XBean::getId).distinct().collect(Collectors.toList());
     }
 
+    public Object invokeInterfaceTest() {
+        List<List<String>> zz = new ArrayList<>();
+        zz.add(new ArrayList<>());
+        return zz.stream()
+                //.flatMap(Collection::stream)
+                //.flatMap(v -> v.stream())
+                .flatMap(Collection::stream)
+                .map(Double::valueOf)
+                .map(BigDecimal::new)
+                .reduce(BigDecimal::add);
+    }
+
+    private void blackHole(Object... ignore) {}
+
+    public interface ILambda {
+        default void run() {
+
+        }
+
+        default void function1(String s) {
+
+        }
+    }
+
+    public static class LambdaFoo implements ILambda {
+
+    }
 }

--- a/demo/java-demo/src/test/java/com/alibaba/demo/lambda/StaticInstanceReferenceTest.java
+++ b/demo/java-demo/src/test/java/com/alibaba/demo/lambda/StaticInstanceReferenceTest.java
@@ -13,18 +13,33 @@ import static com.alibaba.testable.core.matcher.InvocationVerifier.verifyInvoked
  */
 public class StaticInstanceReferenceTest {
 
-    private StaticInstanceReference instance = new StaticInstanceReference();
+    private final StaticInstanceReference instance = new StaticInstanceReference();
 
     //@MockDiagnose(LogLevel.VERBOSE)
     public static class Mock {
-        @MockInvoke(targetClass = StaticInstanceReference.A.class, targetMethod = "doIt")
+        @MockInvoke(targetClass = StaticInstanceReference.StaticClassA.class, targetMethod = "doIt")
         private void mockDoIt() {
+        }
+
+        @MockInvoke(targetClass = StaticInstanceReference.ILambda.class, targetMethod = "run")
+        private void mockFooRun() {
+        }
+
+        @MockInvoke(targetClass = StaticInstanceReference.ILambda.class, targetMethod = "function1")
+        private void mockIFunction1(String s) {
         }
     }
 
     @Test
     public void shouldMockT1() {
         instance.staticMethodReference();
-        verifyInvoked("mockDoIt").withTimes(1);
+        verifyInvoked("mockDoIt").withTimes(2);
+    }
+
+    @Test
+    public void shouldMockFooRun() {
+        instance.interfaceDefault();
+        verifyInvoked("mockFooRun").withTimes(1);
+        verifyInvoked("mockIFunction1").withTimes(1);
     }
 }

--- a/demo/java-demo/src/test/java/com/alibaba/demo/lambda/StaticInstanceReferenceTest.java
+++ b/demo/java-demo/src/test/java/com/alibaba/demo/lambda/StaticInstanceReferenceTest.java
@@ -5,6 +5,9 @@ import com.alibaba.testable.core.annotation.MockInvoke;
 import com.alibaba.testable.core.model.LogLevel;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
+import java.util.stream.Stream;
+
 import static com.alibaba.testable.core.matcher.InvocationVerifier.verifyInvoked;
 
 
@@ -22,24 +25,40 @@ public class StaticInstanceReferenceTest {
         }
 
         @MockInvoke(targetClass = StaticInstanceReference.ILambda.class, targetMethod = "run")
-        private void mockFooRun() {
+        private void mockILambdaRun() {
         }
 
         @MockInvoke(targetClass = StaticInstanceReference.ILambda.class, targetMethod = "function1")
-        private void mockIFunction1(String s) {
+        private void mockILambdaFunction1(String s) {
+        }
+
+        @MockInvoke(targetClass = Collection.class, targetMethod = "stream")
+        <E> Stream<E> mockStream() {
+            return null;
         }
     }
 
     @Test
-    public void shouldMockT1() {
+    public void shouldMockDoIt() {
         instance.staticMethodReference();
-        verifyInvoked("mockDoIt").withTimes(2);
+        verifyInvoked("mockDoIt").withTimes(1);
     }
 
     @Test
-    public void shouldMockFooRun() {
+    public void shouldMockCollectionStream() {
+        instance.collectionInterfaceDefaultOrStatic();
+        verifyInvoked("mockStream").withTimes(1);
+    }
+
+    @Test
+    public void shouldMockInterfaceDefault() {
         instance.interfaceDefault();
-        verifyInvoked("mockFooRun").withTimes(1);
-        verifyInvoked("mockIFunction1").withTimes(1);
+        verifyInvoked("mockILambdaRun").withTimes(1);
+        verifyInvoked("mockILambdaFunction1").withTimes(1);
+    }
+
+    @Test
+    public void shouldMockInterfaceStatic() {
+        instance.interfaceStatic();
     }
 }

--- a/testable-agent/src/main/java/com/alibaba/testable/agent/handler/SourceClassHandler.java
+++ b/testable-agent/src/main/java/com/alibaba/testable/agent/handler/SourceClassHandler.java
@@ -386,7 +386,7 @@ public class SourceClassHandler extends BaseClassHandler {
             //        String s = "";
             //        consumes(s::contains);
             //}
-            boolean external = tag == Opcodes.H_INVOKEVIRTUAL;
+            boolean external = tag == Opcodes.H_INVOKEVIRTUAL || tag == H_INVOKEINTERFACE;
 
             boolean isStatic = tag == Opcodes.H_INVOKESTATIC || external;
 
@@ -434,7 +434,11 @@ public class SourceClassHandler extends BaseClassHandler {
             }
 
             // the method call is static ?
-            mv.visitMethodInsn(Opcodes.H_INVOKESTATIC == tag ? INVOKESTATIC : INVOKEVIRTUAL, handle.getOwner(), handle.getName(), desc, false);
+            if (handle.isInterface() && tag == H_INVOKEINTERFACE) {
+                mv.visitMethodInsn(INVOKEINTERFACE, handle.getOwner(), handle.getName(), desc, true);
+            } else {
+                mv.visitMethodInsn(Opcodes.H_INVOKESTATIC == tag ? INVOKESTATIC : INVOKEVIRTUAL, handle.getOwner(), handle.getName(), desc, false);
+            }
 
             mv.visitInsn(getReturnType(returnType));
 


### PR DESCRIPTION
修复未考虑到interface default 方法, 类似:
```
    public interface ILambda {
        default void run() {
        }

        default void function1(String s) {
        }
    }
```
[0.7.2，对方法引用的支持仍旧存在问题](https://github.com/alibaba/testable-mock/issues/254)