### PR TITLE
Fixed java9+ String makeConcatWithConstants not work for method refer…

### DIFF
--- a/testable-agent/src/main/java/com/alibaba/testable/agent/handler/SourceClassHandler.java
+++ b/testable-agent/src/main/java/com/alibaba/testable/agent/handler/SourceClassHandler.java
@@ -342,7 +342,12 @@ public class SourceClassHandler extends BaseClassHandler {
         for (AbstractInsnNode instruction : mn.instructions) {
             if (instruction.getOpcode() == Opcodes.INVOKEDYNAMIC) {
                 InvokeDynamicInsnNode invokeDynamicInsnNode = (InvokeDynamicInsnNode) instruction;
-                //handleList.add((Handle) invokeDynamicInsnNode.bsmArgs[1]);
+                // java9+ String makeConcatWithConstants will ues INVOKEDYNAMIC to optimize.
+                // When the mock source method has like  <code>"abc" + "def"</code> the bsmArgs length was 1
+                // https://openjdk.java.net/jeps/280
+                if (invokeDynamicInsnNode.bsmArgs.length < 3) {
+                    continue;
+                }
                 BsmArg bsmArg = new BsmArg(invokeDynamicInsnNode.bsmArgs);
                 handleList.add(bsmArg);
             }


### PR DESCRIPTION
Java 9利用InvokeDynamic调用了StringConcatFactory.makeConcatWithConstants方法进行字符串拼接优化，也就是说makeConcatWithConstants的opcode是INVOKEDYNAMIC. 需要过滤掉这种情况

See [mock失效](https://github.com/alibaba/testable-mock/issues/272)